### PR TITLE
Fix file reading in cmd/jwt

### DIFF
--- a/cmd/jwt/main.go
+++ b/cmd/jwt/main.go
@@ -91,9 +91,7 @@ func loadData(p string) ([]byte, error) {
 			return nil, err
 		}
 		rdr = f
-		if err := f.Close(); err != nil {
-			return nil, err
-		}
+		defer f.Close()
 	}
 	return io.ReadAll(rdr)
 }


### PR DESCRIPTION
File reading by cmd/jwt is failing.  Inside of `loadData()`, the `os.File` was being closed before its contents were read by `io.ReadAll()`.  This leads errors like the following.

```
$ go run github.com/golang-jwt/jwt/v5/cmd/jwt@v5.2.3 -alg EdDSA -key privateKey.pem -sign jwt.json 
Error: couldn't read token: read /tmp/access-jwt.json: file already closed
exit status 1
```

The solution is to defer the close operation until the end of the function, which is the way the code had been written prior to PR https://github.com/golang-jwt/jwt/pull/438.

